### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ measures how long a pin is pulled down and send this information to a PHP script
 There is also a frontend based on visualization.
 
 1.
-flash bins to the correponding adresses
+flash bins to the corresponding adresses
 start the chip, you might want to test AT+GMR, it should tell you that it is the DataLogger.
 Also you now have a AT+HELP command
 


### PR DESCRIPTION
@ThomasBarth, I've corrected a typographical error in the documentation of the [ESP8266-SSM](https://github.com/ThomasBarth/ESP8266-SSM) project. Specifically, I've changed correponding to corresponding. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
